### PR TITLE
Explicitly provide text for POD links

### DIFF
--- a/lib/Pod/Weaver/Section/Extends.pm
+++ b/lib/Pod/Weaver/Section/Extends.pm
@@ -41,7 +41,7 @@ sub weave_section {
         ( map { 
             Command->new( {
                 command    => 'item',
-                content    => sprintf '* L<%s>', $_
+                content    => sprintf '* L<%s|%s>', ($_ x 2)
             } ),
         } @parents ),
         Command->new( { 


### PR DESCRIPTION
This practice is recommended by [Perl::Critic::Policy::Documentation::RequirePodLinksIncludeText](https://metacpan.org/pod/Perl::Critic::Policy::Documentation::RequirePodLinksIncludeText).
